### PR TITLE
Bump AGP

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:4.2.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip


### PR DESCRIPTION
```
...
> Task :app:mergeReleaseResources FAILED
> Task :app:processReleaseManifest

FAILURE: Build failed with an exception.
* What went wrong:
Execution failed for task ':app:mergeReleaseResources'.
> Multiple task action failures occurred:
> A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade
> AAPT2 aapt2-4.1.2-6503028-linux Daemon #14: Unexpected error during compile '/home/vagrant/build/de.jonasbernard.tudarmstadtmoodlewrapper/app/src/main/res/mipmap-xxxhdpi/ic_launcher_foreground.png', attempting to stop daemon.

T his should not happen under normal circumstances, please file an issue if it does.

> A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade

> AAPT2 aapt2-4.1.2-6503028-linux Daemon #9: Unexpected error during compile '/home/vagrant/build/de.jonasbernard.tudarmstadtmoodlewrapper/app/src/main/res/mipmap-xxhdpi/ic_launcher.png', attempting to stop daemon.

This should not happen under normal circumstances, please file an issue if it does.

> A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade

> AAPT2 aapt2-4.1.2-6503028-linux Daemon #1: Unexpected error during compile '/home/vagrant/build/de.jonasbernard.tudarmstadtmoodlewrapper/app/src/main/res/mipmap-xhdpi/ic_launcher_foreground.png', attempting to stop daemon.

This should not happen under normal circumstances, please file an issue if it does.

> A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade

> AAPT2 aapt2-4.1.2-6503028-linux Daemon #33: Unexpected error during compile '/home/vagrant/build/de.jonasbernard.tudarmstadtmoodlewrapper/app/src/main/res/mipmap-xxxhdpi/ic_launcher.png', attempting to stop daemon.

This should not happen under normal circumstances, please file an issue if it does.

> A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade

> AAPT2 aapt2-4.1.2-6503028-linux Daemon #25: Unexpected error during compile '/home/vagrant/build/de.jonasbernard.tudarmstadtmoodlewrapper/app/src/main/res/mipmap-xxxhdpi/ic_launcher_round.png', attempting to stop daemon.

This should not happen under normal circumstances, please file an issue if it does.

> A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade

> AAPT2 aapt2-4.1.2-6503028-linux Daemon #34: Unexpected error during compile '/home/vagrant/build/de.jonasbernard.tudarmstadtmoodlewrapper/app/src/main/res/mipmap-xxhdpi/ic_launcher_foreground.png', attempting to stop daemon.

This should not happen under normal circumstances, please file an issue if it does.
```

ref: https://issuetracker.google.com/issues/184872412 This is an issue of AGP 4.1. Updating AGP to 4.2 or above should fix it.

fixed for F-Droid (we'll see heh) in https://gitlab.com/fdroid/fdroiddata/-/commit/a2baeba812f0fa6e7bd59d3366736a246d5ece0e